### PR TITLE
Lista de siglas deve estar em ordem alfabética.

### DIFF
--- a/exemplos/ppgc-tese.tex
+++ b/exemplos/ppgc-tese.tex
@@ -160,14 +160,16 @@ may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
 \end{englishabstract}
 
-% lista de abreviaturas e siglas
-% o parametro deve ser a abreviatura mais longa
+% Lista de abreviaturas e siglas
+% O parâmetro deve ser a abreviatura mais longa.
+% As abreviações devem estar em ordem alfabética (levando em conta só a abreviação mesmo,
+% não o que significa cada palavra).
 \begin{listofabbrv}{SPMD}
-        \item[SMP] Symmetric Multi-Processor
+        \item[ABNT] Associação Brasileira de Normas Técnicas
         \item[NUMA] Non-Uniform Memory Access
         \item[SIMD] Single Instruction Multiple Data
+        \item[SMP] Symmetric Multi-Processor
         \item[SPMD] Single Program Multiple Data
-        \item[ABNT] Associação Brasileira de Normas Técnicas
 \end{listofabbrv}
 
 % idem para a lista de símbolos


### PR DESCRIPTION
O irônico é que a lista de siglas exemplificada no modelo docx atual não está em ordem alfabética porém, no corpo do texto, o modelo docx explica que a lista de siglas deveria estar em ordem alfabética.