### PR TITLE
Including tocstyle obsolete package locally

### DIFF
--- a/inputs/tocstyle.sty
+++ b/inputs/tocstyle.sty
@@ -1,0 +1,952 @@
+%%
+%% This is file `tocstyle.sty',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% tocstyle-obsolete.dtx  (with options: `package,trace,tocstyle')
+%% 
+%% Copyright (c) 2007-2020 by Markus Kohm <komascript(at)gmx.info>
+%% 
+%% This file has been generated.
+%% -----------------------------
+%% 
+%% This work may be distributed and/or modified under the conditions of
+%% the LaTeX Project Public License, version 1.3c of the license.
+%% The latest version of this license is in
+%%   http://www.latex-project.org/lppl.txt
+%% and version 1.3c or later is part of all distributions of LaTeX
+%% version 2005/12/01 or later and of this work.
+%% 
+%% This work has the LPPL maintenance status "not maintained".
+%% 
+%% This file may only be distributed together with the file
+%% `scrpage2-obsolete.dtx'. You may however distribute the file
+%% `scrpage2-obsolete.dtx' without this file.
+%% 
+%% An bilingual (English and German) manual may be generated from the
+%% source file `scrpage2-obsolete.dtx' using:
+%%     pdflatex scrpage2-obsolete.dtx
+%% 
+%% THIS IS AN OBSOLETE, EXPERIMENTAL PACKAGE! YOU SHOULD NOT USE IT!
+%% 
+%%% From File: $Id$
+\NeedsTeXFormat{LaTeX2e}[1995/06/01]
+\ProvidesPackage{tocstyle}
+  [2020/06/06 v0.2k-alpha deprecated package (versatile toc styles)]
+\PackageWarningNoLine{tocstyle}{%
+  THIS IS A DEPRECATED ALPHA VERSION!\MessageBreak
+  USAGE OF THIS VERSION IS ON YOUR OWN RISK!\MessageBreak
+  EVERYTHING MAY HAPPEN!\MessageBreak
+  THE PACKAGE IS FROZEN WITH ALL IT'S BUGS!\MessageBreak
+  THERE IS NO SUPPORT, IF YOU USE THIS PACKAGE!\MessageBreak
+  Maybe it would be better, not to load this package%
+}
+\newif\if@tocstyle@penalties
+\newif\iftocstyle@autolength
+\newif\iftocstyle@indentnotnumbered
+\newcount\tocstyle@indentstyle\tocstyle@indentstyle=\z@
+\newcommand*{\selecttocstyleoption}[1]{%
+  \begingroup
+    \edef\@tempa{#1}%
+    \edef\@tempb{tocbreaksstrict}%
+    \ifx\@tempa\@tempb\aftergroup\@tocstyle@penaltiestrue\else
+      \edef\@tempb{tocbreakscareless}%
+      \ifx\@tempa\@tempb\aftergroup\@tocstyle@penaltiesfalse\else
+        \edef\@tempb{tocindentauto}
+        \ifx\@tempa\@tempb\aftergroup\tocstyle@autolengthtrue\else
+          \edef\@tempb{tocindentmanual}%
+          \ifx\@tempa\@tempb\aftergroup\tocstyle@autolengthfalse\else
+            \edef\@tempb{tocgraduated}%
+            \ifx\@tempa\@tempb
+              \aftergroup\tocstyle@indentstyle\aftergroup\z@
+            \else
+              \edef\@tempb{tocflat}%
+              \ifx\@tempa\@tempb
+                \aftergroup\tocstyle@indentstyle\aftergroup\@ne
+                \aftergroup\relax
+              \else
+                \edef\@tempb{tocfullflat}%
+                \ifx\@tempa\@tempb
+                  \aftergroup\tocstyle@indentstyle\aftergroup\tw@
+                  \aftergroup\relax
+                \else
+                  \edef\@tempb{toctextentriesindented}%
+                  \ifx\@tempa\@tempb\aftergroup\tocstyle@indentnotnumberedtrue
+                  \else
+                    \edef\@tempb{toctextentriesleft}%
+                    \ifx\@tempa\@tempb
+                      \aftergroup\tocstyle@indentnotnumberedfalse
+                    \else
+                      \PackageError{tocstyle}{unknown option `#1'}{%
+                        You've told me to select toc style option
+                        `#1',\MessageBreak
+                        but tocstyle doesn't know an option named `#1'}%
+                    \fi
+                  \fi
+                \fi
+              \fi
+            \fi
+          \fi
+        \fi
+      \fi
+    \fi
+  \endgroup
+}
+\newif\iftochaschapter\tochaschapterfalse
+\ifcsname l@chapter\endcsname
+  \ifcsname chapter\endcsname
+    \tochaschaptertrue
+  \fi
+\fi
+\DeclareOption{tocbreaksstrict}{\selecttocstyleoption\CurrentOption}
+\DeclareOption{tocbreakscareless}{\selecttocstyleoption\CurrentOption}
+\DeclareOption{tocindentauto}{\selecttocstyleoption\CurrentOption}
+\DeclareOption{tocindentmanual}{\selecttocstyleoption\CurrentOption}
+\DeclareOption{toctextentriesindented}{\selecttocstyleoption\CurrentOption}
+\DeclareOption{toctextentriesleft}{\selecttocstyleoption\CurrentOption}
+\DeclareOption{tocgraduated}{\selecttocstyleoption\CurrentOption}
+\DeclareOption{tocflat}{\selecttocstyleoption\CurrentOption}
+\DeclareOption{tocfullflat}{\selecttocstyleoption\CurrentOption}
+\ExecuteOptions{tocbreaksstrict,tocindentauto,tocgraduated,%
+  toctextentriesleft}
+\ProcessOptions\relax
+\ifcsname if@tocleft\endcsname
+  \expandafter\let\csname if@tempswa\expandafter\endcsname
+  \csname if@tocleft\endcsname
+\else
+  \@tempswafalse
+\fi
+\if@tempswa
+  \PackageWarningNoLine{tocstyle}{%
+    You should not use class option `toc=flat'!\MessageBreak
+    This may result in errors or unexpected results.\MessageBreak
+    I'll try to deactivate `toc=flat', now.\MessageBreak
+    You may use package options `tocflat' and\MessageBreak
+    `tocindentauto' instead of `toc=flat'}%
+  \csname @tocleftfalse\endcsname
+\fi
+\newcommand*\tocstyle@saved@starttoc{}
+\let\tocstyle@saved@starttoc\@starttoc
+\renewcommand*{\@starttoc}[1]{%
+  \tocstyle@pre@starttoc{#1}%
+  \tocstyle@saved@starttoc{#1}%
+  \tocstyle@post@starttoc{#1}%
+}
+\newcommand*{\tocstyle@saved@dottedtocline}{}
+\newcommand*{\tocstyle@dottedtocline}[5]{%
+  \let\numberline\tocstyle@numberline
+  \ifnum #1>\c@tocdepth \else
+    \if@tocstyle@penalties
+      \begingroup
+        \@tempcnta 20010
+        \advance \@tempcnta by -#1
+        \ifnum \@tempcnta>\lastpenalty
+          \aftergroup\penalty\aftergroup\@lowpenalty
+        \fi
+      \endgroup
+    \fi
+    \edef\tocstyledepth{#1}%
+    \tocstyle@activate@features
+    \ifx\tocstyle@feature@entryvskip\relax
+      \vskip \z@ \@plus.2\p@
+    \else
+      \addvspace{\tocstyle@feature@entryvskip}%
+    \fi
+    {%
+      \parskip \z@ \parindent \z@ \leftskip \z@ \rightskip \z@
+      \tocstyle@feature@raggedhook
+      \@tempdima #3\relax
+      \@tempdimb #2\relax
+      \typeout{number indent by \string\l@... (\tocstyleTOC, \tocstyledepth): \space\the\@tempdimb}%
+      \typeout{text indent by \string\l@... (\tocstyleTOC, \tocstyledepth): \space\the\@tempdima}%
+      \ifnum #1>\z@\relax
+        \@tempcnta #1\relax \advance\@tempcnta \m@ne
+        \ifcsname tocstyle@maxskipwidth@\tocstyleTOC @\the\@tempcnta\endcsname
+          \ifcsname tocstyle@maxnumwidth@\tocstyleTOC @\the\@tempcnta\endcsname
+            \@tempdimb
+            \csname tocstyle@maxskipwidth@\tocstyleTOC @\the\@tempcnta\endcsname
+            \advance\@tempdimb
+            \csname tocstyle@maxnumwidth@\tocstyleTOC @\the\@tempcnta\endcsname
+          \fi
+        \fi
+      \fi
+      \typeout{number indent by parent (\tocstyleTOC, \tocstyledepth): \space\the\@tempdimb}%
+      \ifcsname tocstyle@skipwidth@\tocstyleTOC @#1\endcsname
+        \ifdim \@tempdimb>
+        \csname tocstyle@skipwidth@\tocstyleTOC @#1\endcsname\relax
+          \expandafter\xdef\csname tocstyle@skipwidth@\tocstyleTOC
+          @#1\endcsname{\the\@tempdimb}%
+        \fi
+      \else
+        \expandafter\xdef\csname tocstyle@skipwidth@\tocstyleTOC
+        @#1\endcsname{\the\@tempdimb}%
+      \fi
+      \iftocstyle@autolength
+        \ifcsname tocstyle@maxskipwidth@\tocstyleTOC @#1\endcsname
+          \@tempdimb \csname tocstyle@maxskipwidth@\tocstyleTOC @#1\endcsname
+          \relax
+        \fi
+        \ifcsname tocstyle@maxnumwidth@\tocstyleTOC @#1\endcsname
+          \@tempdima \csname tocstyle@maxnumwidth@\tocstyleTOC @#1\endcsname
+          \relax
+        \fi
+        \typeout{text indent calculated (\tocstyleTOC, \tocstyledepth): \the\@tempdima}%
+        \typeout{number indent calculated (\tocstyleTOC, \tocstyledepth): \the\@tempdimb}%
+      \else
+        \@tempdimb #2\relax
+        \typeout{number indent explicite (\tocstyleTOC, \tocstyledepth): \the\@tempdimb}%
+      \fi
+      \ifcsname tocstyle@unumwidth@\tocstyleTOC @\endcsname
+        \ifdim \@tempdima>
+        \csname tocstyle@unumwidth@\tocstyleTOC @\endcsname\relax
+          \expandafter\xdef\csname tocstyle@unumwidth@\tocstyleTOC
+          @\endcsname{\the\@tempdima}%
+        \fi
+      \else
+        \expandafter\xdef\csname tocstyle@unumwidth@\tocstyleTOC
+        @\endcsname{\the\@tempdima}%
+      \fi
+      \ifcase\tocstyle@indentstyle\relax\else
+        \@tempdimb \z@
+        \ifcsname tocstyle@maxunumwidth@\tocstyleTOC @\endcsname
+          \@tempdima \csname tocstyle@maxunumwidth@\tocstyleTOC @\endcsname
+          \relax
+        \fi
+        \typeout{text noindent (\tocstyleTOC, \tocstyledepth): \the\@tempdima}%
+        \typeout{number noindent (\tocstyleTOC, \tocstyledepth): \the\@tempdimb}%
+      \fi
+      \advance\parindent \@tempdimb\@afterindenttrue
+      \advance\leftskip \parindent
+      \advance\rightskip \@tocrmarg
+      \parfillskip -\rightskip
+      \ifx\tocstyle@feature@parfillskip\relax\else
+        \advance\parfillskip \tocstyle@feature@parfillskip\relax
+      \fi
+      \interlinepenalty\@M
+      \leavevmode
+      \advance\leftskip \@tempdima
+      \null\nobreak
+      \iftocstyle@indentnotnumbered\else
+        \hskip -\leftskip
+      \fi
+      \tocstyle@feature@entryhook
+      {#4}\nobreak
+      \ifx\tocstyle@feature@leaders\relax
+        \leaders\hbox{$\m@th
+          \mkern \@dotsep mu\hbox{\tocstyle@feature@dothook .}%
+          \mkern \@dotsep mu$}\hfill
+      \else
+        \tocstyle@feature@leaders
+      \fi
+      \nobreak
+      \ifx\tocstyle@feature@pagenumberbox\relax
+      \hb@xt@\@pnumwidth{\hfil\tocstyle@feature@pagenumberhook #5%
+        \kern-\p@\kern\p@}%
+      \else
+        \tocstyle@feature@pagenumberbox{\tocstyle@feature@pagenumberhook #5%
+        \kern-\p@\kern\p@}%
+      \fi
+      \par
+    }%
+    \if@tocstyle@penalties
+      \bgroup
+        \@tempcnta 20009
+        \advance\@tempcnta by -#1
+        \edef\reserved@a{\egroup\penalty\the\@tempcnta\relax}%
+      \reserved@a
+    \fi
+  \fi}
+\newcommand*{\tocstyle@saved@numberline}{}
+\newcommand*{\tocstyle@numberline}[1]{%
+  \begingroup
+    \ifx\tocstyle@feature@spaceafternumber\relax
+      \settowidth\@tempdima{\tocstyle@@numberline{#1}\enskip}%
+    \else
+      \settowidth\@tempdima{\tocstyle@@numberline{#1}}%
+      \advance \@tempdima \tocstyle@feature@spaceafternumber\relax
+    \fi
+    \ifcsname tocstyle@numwidth@\tocstyleTOC @\tocstyledepth\endcsname
+      \ifdim \@tempdima >
+      \csname tocstyle@numwidth@\tocstyleTOC @\tocstyledepth\endcsname\relax
+        \expandafter\xdef\csname tocstyle@numwidth@\tocstyleTOC
+        @\tocstyledepth\endcsname{\the\@tempdima}%
+      \fi
+    \else
+      \expandafter\xdef\csname tocstyle@numwidth@\tocstyleTOC
+      @\tocstyledepth\endcsname{\the\@tempdima}%
+    \fi
+  \endgroup
+  \iftocstyle@indentnotnumbered
+    \hskip -\leftskip
+  \fi
+  \ifcase \tocstyle@indentstyle
+    \hb@xt@\@tempdima{\tocstyle@@numberline{#1}\hfil}%
+  \or
+    \hb@xt@\@tempdima{\tocstyle@@numberline{#1}\hfil}%
+  \else
+    \ifx\tocstyle@feature@spaceafternumber\relax
+      \hbox{\tocstyle@@numberline{#1}\enskip}%
+    \else
+      \hbox{\tocstyle@@numberline{#1}\hskip
+        \tocstyle@feature@spaceafternumber\relax}%
+    \fi
+  \fi
+}
+\newcommand*{\tocstyle@@numberline}[1]{%
+  #1\csname autodot\endcsname
+}
+\AtBeginDocument{%
+  \@ifpackageloaded{tocbasic}{%
+    \@ifpackagelater{tocbasic}{2016/03/01}{%
+      \PackageWarningNoLine{tocstyle}{%
+        Usage of `tocstyle' with new `tocbasic' detected.\MessageBreak
+        This is not an error! You can do this.\MessageBreak
+        Nevertheless, you should note, combining `tocstyle'\MessageBreak
+        with this version of `tocbasic' will break several\MessageBreak
+        features of `tocbasic'. You should use `tocstyle'\MessageBreak
+        features instead of `tocbasic' attributes for all\MessageBreak
+        entry changes you want.\MessageBreak
+        You may also get additional warnings because of\MessageBreak
+        redefined `\string\numberline'. Ignore them}%
+    }{}%
+  }{}%
+  \@ifpackageloaded{etoc}{%
+    \PackageWarningNoLine{tocstyle}{%
+      Usage of `tocstyle' with `etoc' detected.\MessageBreak
+      I suggest to use either `tocstyle' or `etoc'\MessageBreak
+      but not both of them together}%
+  }{}%
+  \@ifpackageloaded{titletoc}{%
+    \PackageWarningNoLine{tocstyle}{%
+      Usage of `tocstyle' with `titletoc' detected.\MessageBreak
+      I suggest to use either `tocstyle' or `titletoc'\MessageBreak
+      but not both of them together. I expect even\MessageBreak
+      error messages because of this combination}%
+  }{}%
+  \def\tocstyle@test@level{-1}%
+  \def\tocstyle@test@levelname{part}%
+  \@whilesw\ifcsname l@\tocstyle@test@levelname\endcsname\fi{%
+    \setbox\@tempboxa\vbox{\hsize\maxdimen
+      \let\normalcolor\relax
+      \let\color\@gobble
+      \edef\reserved@a{%
+        \expandafter\noexpand\csname l@\tocstyle@test@levelname\endcsname{%
+          \noexpand\tocstyle@l@define{\tocstyle@test@levelname}%
+                                     {\tocstyle@test@level}%
+        }{}%
+      }%
+      \reserved@a
+    }%
+    \edef\tocstyle@test@levelname{sub\tocstyle@test@levelname}%
+    \edef\tocstyle@test@level{\the\numexpr\tocstyle@test@level+1}%
+  }%
+  \ifnum\tocstyle@test@level<\z@
+    \def\tocstyle@test@level{0}%
+  \fi
+  \def\tocstyle@test@levelname{chapter}%
+  \@whilesw\ifcsname l@\tocstyle@test@levelname\endcsname\fi{%
+    \setbox\@tempboxa\vbox{\hsize\maxdimen
+      \let\normalcolor\relax
+      \let\color\@gobble
+      \edef\reserved@a{%
+        \expandafter\noexpand\csname l@\tocstyle@test@levelname\endcsname{%
+          \noexpand\tocstyle@l@define{\tocstyle@test@levelname}%
+                                     {\tocstyle@test@level}%
+        }{}%
+      }%
+      \reserved@a
+    }%
+    \edef\tocstyle@test@levelname{sub\tocstyle@test@levelname}%
+    \edef\tocstyle@test@level{\the\numexpr\tocstyle@test@level+1}%
+  }%
+  \ifnum\tocstyle@test@level<\@ne
+    \def\tocstyle@test@level{1}%
+  \fi
+  \def\tocstyle@test@levelname{section}%
+  \@whilesw\ifcsname l@\tocstyle@test@levelname\endcsname\fi{%
+    \setbox\@tempboxa\vbox{\hsize\maxdimen
+      \let\normalcolor\relax
+      \let\color\@gobble
+      \edef\reserved@a{%
+        \expandafter\noexpand\csname l@\tocstyle@test@levelname\endcsname{%
+          \noexpand\tocstyle@l@define{\tocstyle@test@levelname}%
+                                     {\tocstyle@test@level}%
+        }{}%
+      }%
+      \reserved@a
+    }%
+    \edef\tocstyle@test@levelname{sub\tocstyle@test@levelname}%
+    \edef\tocstyle@test@level{\the\numexpr\tocstyle@test@level+1}%
+  }%
+  \def\tocstyle@test@levelname{paragraph}%
+  \@whilesw\ifcsname l@\tocstyle@test@levelname\endcsname\fi{%
+    \setbox\@tempboxa\vbox{\hsize\maxdimen
+      \let\normalcolor\relax
+      \let\color\@gobble
+      \edef\reserved@a{%
+        \expandafter\noexpand\csname l@\tocstyle@test@levelname\endcsname{%
+          \noexpand\tocstyle@l@define{\tocstyle@test@levelname}%
+                                     {\tocstyle@test@level}%
+        }{}%
+      }%
+      \reserved@a
+    }%
+    \edef\tocstyle@test@levelname{sub\tocstyle@test@levelname}%
+    \edef\tocstyle@test@level{\the\numexpr\tocstyle@test@level+1}%
+  }%
+  \def\tocstyle@test@level{1}%
+  \def\tocstyle@test@levelname{table}%
+  \@whilesw\ifcsname l@\tocstyle@test@levelname\endcsname\fi{%
+    \setbox\@tempboxa\vbox{\hsize\maxdimen
+      \let\normalcolor\relax
+      \let\color\@gobble
+      \edef\reserved@a{%
+        \expandafter\noexpand\csname l@\tocstyle@test@levelname\endcsname{%
+          \noexpand\tocstyle@l@define{\tocstyle@test@levelname}%
+                                     {\tocstyle@test@level}%
+        }{}%
+      }%
+      \reserved@a
+    }%
+    \edef\tocstyle@test@levelname{sub\tocstyle@test@levelname}%
+    \edef\tocstyle@test@level{\the\numexpr\tocstyle@test@level+1}%
+  }%
+  \def\tocstyle@test@level{1}%
+  \def\tocstyle@test@levelname{figure}%
+  \@whilesw\ifcsname l@\tocstyle@test@levelname\endcsname\fi{%
+    \setbox\@tempboxa\vbox{\hsize\maxdimen
+      \let\normalcolor\relax
+      \let\color\@gobble
+      \edef\reserved@a{%
+        \expandafter\noexpand\csname l@\tocstyle@test@levelname\endcsname{%
+          \noexpand\tocstyle@l@define{\tocstyle@test@levelname}%
+                                     {\tocstyle@test@level}%
+        }{}%
+      }%
+      \reserved@a
+    }%
+    \edef\tocstyle@test@levelname{sub\tocstyle@test@levelname}%
+    \edef\tocstyle@test@level{\the\numexpr\tocstyle@test@level+1}%
+  }%
+  \def\@tempa#1#2#3#4#5{%
+    \ifnum #1>\c@tocdepth \else
+      \vskip \z@ \@plus.2\p@
+      {\leftskip #2\relax \rightskip \@tocrmarg \parfillskip -\rightskip
+       \parindent #2\relax\@afterindenttrue
+       \interlinepenalty\@M
+       \leavevmode
+       \@tempdima #3\relax
+       \advance\leftskip \@tempdima \null\nobreak\hskip -\leftskip
+       {#4}\nobreak
+       \leaders\hbox{$\m@th
+          \mkern \@dotsep mu\hbox{.}\mkern \@dotsep
+          mu$}\hfill
+       \nobreak
+       \hb@xt@\@pnumwidth{\hfil \normalfont \normalcolor #5}%
+       \par}%
+    \fi}%
+  \ifx\@dottedtocline\@tempa\else
+    \def\@tempa#1#2#3#4#5{%
+      \ifnum #1>\c@tocdepth \else
+        \vskip \z@ \@plus.2\p@
+        {\leftskip #2\relax \rightskip \@tocrmarg \parfillskip -\rightskip
+         \parindent #2\relax\@afterindenttrue
+         \interlinepenalty\@M
+         \leavevmode
+         \@tempdima #3\relax
+         \advance\leftskip \@tempdima \null\nobreak\hskip -\leftskip
+         {#4}\nobreak
+         \leaders\hbox{$\m@th
+            \mkern \@dotsep mu\hbox{.}\mkern \@dotsep
+            mu$}\hfill
+         \nobreak
+         \hb@xt@\@pnumwidth{\hfil \normalfont \normalcolor #5\kern-\p@\kern\p@}%
+         \par}%
+      \fi}%
+    \ifx\@dottedtocline\@tempa\else
+      \tocstyle@macrochangewarning\@dottedtocline
+    \fi
+  \fi
+  \let\tocstyle@saved@dottedtocline\@dottedtocline
+  \def\@tempa#1{\hb@xt@\@tempdima{#1\autodot\hfil}}%
+  \ifx\numberline\@tempa\else
+    \def\@tempa#1{\hb@xt@\@tempdima{#1\hfil}}%
+    \ifx\numberline@tempa\else
+      \tocstyle@macrochangewarning\numberline
+    \fi
+  \fi
+  \let\tocstyle@saved@numberline\numberline
+}
+\newcommand*{\tocstyle@macrochangewarning}[1]{%
+  \PackageWarningNoLine{tocstyle}{%
+    unexpected \string#1\space definition!\MessageBreak
+    You are either using an unknown LaTeX kernel\MessageBreak
+    version, an unknown class or package, that redefines\MessageBreak
+    \string#1, or a \string#1\space
+    redefinition\MessageBreak
+    at the document preamble.\MessageBreak
+    Because of this you may get unexpected results!\MessageBreak
+    Maybe it would be better not to use package tocstyle}%
+  \PackageInfo{tocstyle}{Unexpected definition is:\MessageBreak
+    \meaning#1}%
+}
+\newcommand*{\tocstyle@activate@all@l}{}
+\newcommand*{\tocstyle@l@define}[2]{%
+  \advance\leftskip-\@tempdima
+  \edef\@tempa{%
+    \noexpand\global\noexpand\let
+    \expandafter\noexpand\csname tocstyle@saved@l@#1\endcsname
+    \expandafter\noexpand\csname l@#1\endcsname
+    \noexpand\gdef
+    \expandafter\noexpand\csname tocstyle@l@#1\endcsname{%
+      \noexpand\@dottedtocline{#2}{\the\leftskip}{\the\@tempdima}}%
+    \noexpand\g@addto@macro\noexpand\tocstyle@activate@all@l{%
+      \noexpand\let\expandafter\noexpand\csname l@#1\endcsname
+      \expandafter\noexpand\csname tocstyle@l@#1\endcsname
+    }%
+  }%
+  \PackageInfo{tocstyle}{prepare \expandafter\string
+    \csname l@#1\endcsname\space for redefinition}%
+  \@tempa
+}
+\newcommand*{\showtoc}[2][\aliastoc\tocstyleTOC\tocstyleAliasTOC]{%
+  \ifcsname tocstyle@copyname@#2\endcsname
+    \@tempcnta \csname tocstyle@copyname@#2\endcsname\relax
+    \advance\@tempcnta \@ne
+    \expandafter\xdef\csname tocstyle@copyname@#2\endcsname{\the\@tempcnta}%
+  \else
+    \expandafter\xdef\csname tocstyle@copyname@#2\endcsname{1}%
+  \fi
+  \ifx\@dofilelist\relax\let\@dofilelist\@empty\fi
+  \edef\@tempa{\noexpand\g@addto@macro\noexpand\@dofilelist{%
+      \noexpand\tocstyle@copy@toc{#2}{\csname
+        tocstyle@copyname@#2\endcsname}}%
+  }\@tempa%
+  \begingroup
+    \edef\tocstyleAliasTOC{#2}%
+    \edef\tocstyleTOC{#2\csname tocstyle@copyname@#2\endcsname}%
+    #1
+    \tocstyle@pre@starttoc{#2\csname tocstyle@copyname@#2\endcsname}%
+    \makeatletter
+    \@input{\jobname.#2\csname tocstyle@copyname@#2\endcsname}%
+    \@nobreakfalse
+    \tocstyle@post@starttoc{#2\csname tocstyle@copyname@#2\endcsname}%
+  \endgroup
+}
+\newcommand*{\tocstyle@copy@toc}[2]{%
+  \if@filesw
+    \begingroup
+      \endlinechar=\m@ne
+      \immediate\closeout\csname tf@#1\endcsname
+      \immediate\openin\@inputcheck \jobname.#1
+      \immediate\openout\@partaux \jobname.#1#2
+      \loop\unless\ifeof\@inputcheck
+        \immediate\readline\@inputcheck to \@tempa
+        \immediate\write\@partaux{\@tempa}%
+      \repeat
+      \immediate\closeout\@partaux
+      \immediate\closein\@inputcheck
+    \endgroup
+  \fi
+}
+\newcommand*{\aliastoc}[2]{%
+  \expandafter\edef\csname tocstyle@alias@TOC@#1\endcsname{#2}%
+}
+\newcommand*{\tocstyle@pre@starttoc}[1]{%
+  \begingroup
+    \expandafter\ifx\csname tocstyle@deactivated@\endcsname\relax
+      \expandafter\ifx\csname tocstyle@deactivated@#1\endcsname\relax\relax
+        \tocstyle@activetrue
+      \else
+        \tocstyle@activefalse
+      \fi
+    \else
+      \tocstyle@activefalse
+    \fi
+    \iftocstyle@active
+      \let\@dottedtocline\tocstyle@dottedtocline
+      \parskip \z@
+      \parindent \z@
+      \parfillskip \z@\@plus 1fil
+      \ifcsname tocstyle@alias@TOC@#1\endcsname
+        \edef\tocstyleAliasTOC{\csname tocstyle@alias@TOC@#1\endcsname}%
+      \else
+        \edef\tocstyleAliasTOC{#1}%
+      \fi
+      \edef\tocstyleTOC{#1}%
+      \tocstyle@activate@all@l
+    \fi
+}
+\newcommand*{\tocstyle@post@starttoc}[1]{%
+    \iftocstyle@active
+      \if@filesw
+        \ifcsname tocstyle@unumwidth@#1@\endcsname
+          \protected@write\@auxout{}{%
+            \protect\tocstyle@set@width{unum}{#1}{}{%
+              \csname tocstyle@unumwidth@#1@\endcsname}%
+          }%
+        \fi
+        \expandafter\let\expandafter\@tempa
+          \csname tocstyle@depthlist@#1\endcsname
+        \ifx\@tempa\relax\else
+          \expandafter\@for \expandafter\@tempa\expandafter:\expandafter=\@tempa
+          \do {%
+            \ifcsname tocstyle@numwidth@#1@\@tempa\endcsname
+              \protected@write\@auxout{}{%
+                \protect\tocstyle@set@width{num}{#1}{\@tempa}{%
+                  \csname tocstyle@numwidth@#1@\@tempa\endcsname}%
+              }%
+            \fi
+            \ifcsname tocstyle@skipwidth@#1@\@tempa\endcsname
+              \protected@write\@auxout{}{%
+                \protect\tocstyle@set@width{skip}{#1}{\@tempa}{%
+                  \csname tocstyle@skipwidth@#1@\@tempa\endcsname}%
+              }%
+            \fi
+          }%
+        \fi
+      \fi
+    \fi
+  \endgroup
+}
+\newcommand*{\tocstyle@set@width}[4]{%
+  \iftocstyle@indentnotnumbered
+    \ifdim #4<\z@
+      \expandafter\gdef\csname tocstyle@max#1width@#2@#3\endcsname{%
+        \dimexpr #4/2\relax}%
+    \else
+      \expandafter\gdef\csname tocstyle@max#1width@#2@#3\endcsname{#4}%
+    \fi
+  \else
+    \ifdim #4<\z@
+      \expandafter\gdef\csname tocstyle@max#1width@#2@#3\endcsname{\z@}%
+    \else
+      \expandafter\gdef\csname tocstyle@max#1width@#2@#3\endcsname{#4}%
+    \fi
+  \fi
+}
+\AtBeginDocument{%
+  \if@filesw
+    \immediate\write\@auxout{%
+      \string\providecommand*\string\tocstyle@set@width[4]{}%
+    }%
+  \fi
+}
+\newcommand*{\tocstyleTOC}{}
+\newcommand*{\tocstyleAliasTOC}{}
+\newcommand*{\tocstyledepth}{}
+\newif\iftocstyle@active
+\newcommand*{\deactivatetocstyle}[1][]{%
+  \expandafter\let\csname tocstyle@deactivated@#1\endcsname\@empty}
+\newcommand*{\reactivatetocstyle}[1][]{%
+  \expandafter\let\csname tocstyle@deactivated@#1\endcsname\relax}
+\newcommand*{\@settocfeature}[1][]{%
+  \kernel@ifnextchar[ {\@@settocfeature[{#1}]}{\@@settocfeature[{#1}][]}
+}
+\def\@@settocfeature[#1][#2]#3#4{%
+  \typeout{exclude: \tocstyle@feature@excludelist}%
+  \@expandtwoargs\in@{,#3,}{,\tocstyle@feature@excludelist,}%
+  \ifin@\else
+    \expandafter\ifcsname tocstyle@feature@#3\endcsname
+      \@namedef{tocstyle@feature@#3@#1@#2}{#4}%
+      \begingroup
+        \expandafter\let\expandafter\@tempa
+        \csname tocstyle@commandlist@#1\endcsname
+        \@expandtwoargs\in@{,tocstyle@feature@#3@#1@#2,}{,\@tempa,}%
+        \ifin@\let\@tempa\endgroup\else
+          \edef\@tempa{\endgroup
+            \noexpand\expandafter\noexpand\ifx
+            \noexpand\csname tocstyle@commandlist@#1\noexpand\endcsname\relax
+              \noexpand\expandafter\noexpand\expandafter\noexpand\expandafter
+              \noexpand\def
+            \noexpand\else
+              \noexpand\expandafter\noexpand\expandafter\noexpand\expandafter
+              \noexpand\l@addto@macro
+            \noexpand\fi
+            \noexpand\csname tocstyle@commandlist@#1\noexpand\endcsname%
+            {tocstyle@feature@#3@#1@#2,}}%
+        \fi
+      \@tempa
+    \else
+      \PackageError{tocstyle}{unkown feature `#3'}{%
+        You've told me to set up toc style feature `#3',\MessageBreak
+        but I don't know this feature.\MessageBreak
+        See the tocstyle manual for all known feature.\MessageBreak
+      }%
+    \fi
+  \fi
+}
+\newcommand*{\settocfeature}{}
+\let\settocfeature\@settocfeature
+\providecommand{\l@addto@macro}[2]{%
+  \edef#1{\unexpanded\expandafter{#1#2}}%
+}%
+\newcommand*{\@settocstylefeature}{%
+  \kernel@ifnextchar[ {\@settocfeature[]}{\@settocfeature[][]}%
+}
+\newcommand*{\settocstylefeature}{}
+\let\settocstylefeature\@settocstylefeature
+\newcommand*{\tocstyle@activate@features}{%
+  \expandafter\ifx\csname tocstyle@depthlist@\tocstyleTOC\endcsname\relax
+    \expandafter\xdef\csname tocstyle@depthlist@\tocstyleTOC\endcsname{%
+      \tocstyledepth}%
+  \else
+    \expandafter\let\expandafter\@tempa
+    \csname tocstyle@depthlist@\tocstyleTOC\endcsname
+    \@expandtwoargs\in@{,\tocstyledepth,}{,\@tempa,}%
+    \ifin@\else
+      \expandafter\xdef\csname tocstyle@depthlist@\tocstyleTOC\endcsname{%
+        \csname tocstyle@depthlist@\tocstyleTOC\endcsname,\tocstyledepth}%
+    \fi
+  \fi
+  \expandafter\@for \expandafter\@tempa
+  \expandafter:\expandafter=\tocstyle@featurelist \do
+  {%
+    \@ifundefined{tocstyle@feature@\@tempa @\tocstyleAliasTOC @\tocstyledepth}{%
+      \@ifundefined{tocstyle@feature@\@tempa @@\tocstyledepth}{%
+        \@ifundefined{tocstyle@feature@\@tempa @\tocstyleAliasTOC @}{%
+          \@ifundefined{tocstyle@feature@\@tempa @@}{%
+            \expandafter\let\csname tocstyle@feature@\@tempa\endcsname\relax
+          }{%
+            \expandafter\let\csname tocstyle@feature@\@tempa
+            \expandafter\endcsname
+            \csname tocstyle@feature@\@tempa @@\endcsname
+          }%
+        }{%
+          \expandafter\let\csname tocstyle@feature@\@tempa
+          \expandafter\endcsname
+          \csname tocstyle@feature@\@tempa @\tocstyleAliasTOC @\endcsname
+        }%
+      }{%
+        \expandafter\let\csname tocstyle@feature@\@tempa
+        \expandafter\endcsname
+        \csname tocstyle@feature@\@tempa @@\tocstyledepth\endcsname
+      }%
+    }{%
+      \expandafter\let\csname tocstyle@feature@\@tempa
+      \expandafter\endcsname
+      \csname tocstyle@feature@\@tempa @\tocstyleAliasTOC @\tocstyledepth\endcsname
+    }%
+  }%
+}
+\newcommand*{\newtocstyle}{%
+  \kernel@ifnextchar [{\@newtocstyle}{\@newtocstyle[]}}
+\newcommand*{\@newtocstyle}{}
+\def\@newtocstyle[#1]{%
+  \kernel@ifnextchar [{\@@newtocstyle[{#1}]}{\@newtocstyle[{#1}][]}}
+\newcommand*{\@@newtocstyle}{}
+\def\@@newtocstyle[#1][#2]#3#4{%
+  \@ifundefined{tocstyle@style@#3}{%
+    \@ifundefined{tocstyle@style@#1}{%
+      \ifx \relax#1\relax\else
+        \PackageError{tocstyle}{unknown parent TOC style `#1'}{%
+          You've told me to inheritate parent TOC style `#1',\MessageBreak
+          but there's no TOC style `#1' defined.}%
+      \fi
+      \expandafter\def\csname tocstyle@style@#3\endcsname{#4}%
+    }{%
+      \expandafter\def\csname tocstyle@style@#3\endcsname{%
+        \edef\reserved@a{%
+          \noexpand\l@addto@macro\noexpand\tocstyle@feature@excludelist{#2}%
+          \noexpand\@usetocstyle{#1}%
+          \noexpand\def\noexpand\tocstyle@feature@excludelist{%
+            \tocstyle@feature@excludelist}%
+        }\reserved@a
+        #4%
+      }%
+    }%
+  }{%
+    \PackageError{tocstyle}{TOC style `#3' already defined}{%
+      You've tried to define a new TOC style `#3',\MessageBreak
+      but there's already a TOC style named `#3'.}%
+  }%
+}
+\newcommand*{\tocstyle@feature@excludelist}{}
+\newcommand*{\usetocstyle}[2][]{%
+  \@ifundefined{tocstyle@deprecated@style@#2}{%
+    \@ifundefined{tocstyle@style@#2}{%
+      \PackageError{tocstyle}{unknown TOC style `#2'}{%
+        You've told me to use TOC style `#2',\MessageBreak
+        but there's no TOC style `#2' defined.}%
+    }{%
+      \def\settocfeature{%
+        \kernel@ifnextchar[ %]
+        {\@@settocfeature[{#1}]}{\@@settocfeature[{#1}][]}%
+      }%
+      \let\settocstylefeature\settocfeature
+      \expandafter\ifx\csname tocstyle@commandlist@#1\endcsname\relax
+      \else
+        \expandafter\expandafter\expandafter\@for
+        \expandafter\expandafter\expandafter\@tempa
+        \expandafter\expandafter\expandafter:%
+        \expandafter\expandafter\expandafter=%
+        \csname tocstyle@commandlist@#1\endcsname
+        \do{%
+          \expandafter\let\csname \@tempa\endcsname\relax
+        }%
+        \expandafter\let\csname tocstyle@commandlist@#1\endcsname\relax
+      \fi
+      \@usetocstyle{#2}%
+      \let\settocfeature\@settocfeature
+      \let\settocstylefeature\@settocstylefeature
+    }%
+  }{%
+    \expandafter\ifx\csname tocstyle@deprecated@style@#2\endcsname\@empty
+      \PackageWarning{tocstyle}{%
+        deprecated TOC style `#2'!\MessageBreak
+        You should not longer use this style,\MessageBreak
+        because it will be removed soon.\MessageBreak
+        You should select another TOC style}%
+      \usetocstyle[{#1}]{deprecated@#2}%
+    \else
+      \PackageWarning{tocstyle}{%
+        deprecated TOC style `#2'!\MessageBreak
+        You should use TOC style '\csname
+        tocstyle@deprecated@style@#2\endcsname'\MessageBreak
+        instead of `#2'}%
+    \fi
+  }%
+}
+\newcommand*{\@usetocstyle}[1]{%
+  \csname tocstyle@style@#1\endcsname
+}
+\newcommand*{\tocstyle@featurelist}{%
+  pagenumberhook,entryhook,dothook,entryvskip,leaders,raggedhook,%
+  spaceafternumber,parfillskip,pagenumberbox,%
+}
+\newcommand*{\tocstyle@feature@pagenumberhook}{}
+\let\tocstyle@feature@pagenumberhook\relax
+\newcommand*{\tocstyle@feature@pagenumberbox}{}
+\let\tocstyle@feature@pagenumberbox\relax
+\newcommand*{\tocstye@feature@entryhook}{}
+\let\tocstyle@feature@entryhook\relax
+\newcommand*{\tocstye@feature@dothook}{}
+\let\tocstyle@feature@dothook\relax
+\newcommand*{\tocstye@feature@entryvskip}{}
+\let\tocstyle@feature@entryvskip\relax
+\newcommand*{\tocstye@feature@leaders}{}
+\let\tocstyle@feature@leaders\relax
+\newcommand*{\tocstye@feature@parfillskip}{}
+\let\tocstyle@feature@parfillskip\relax
+\newcommand*{\tocstye@feature@raggedhook}{}
+\let\tocstyle@feature@raggedhook\relax
+\newcommand*{\tocstye@feature@spaceafternumber}{}
+\let\tocstyle@feature@spaceafternumber\relax
+\newcommand*{\iftochasdepth}[2]{%
+  \begingroup
+    \expandafter\let\expandafter\@tempa\csname tocstyle@depthlist@#1\endcsname
+    \ifx\@tempa\relax
+      \aftergroup\@secondoftwo
+    \else
+      \@expandtwoargs\in@{,#2,}{,\@tempa}%
+      \expandafter\aftergroup\ifin@
+        \@firstoftwo
+      \else
+        \@secondoftwo
+      \fi
+    \fi
+  \endgroup
+}
+\providecommand*{\ext@toc}{toc}
+\newtocstyle{standard}{%
+  \settocfeature{dothook}{\normalfont}%
+  \settocfeature[-1]{entryhook}{\bfseries}%
+  \settocfeature[-1]{entryvskip}{2.25em\@plus\p@}%
+  \settocfeature[-1]{leaders}{\hfill}%
+  \settocfeature[0]{entryvskip}{1em\@plus\p@}%
+  \settocfeature[0]{leaders}{\hfill}%
+  \settocfeature[0]{entryhook}{\bfseries}
+  \iftochaschapter\else
+    \settocfeature[1]{entryvskip}{1em\@plus\p@}%
+    \settocfeature[1]{leaders}{\hfill}%
+    \settocfeature[1]{entryhook}{%
+      \ifx\tocstyleAliasTOC\ext@toc\bfseries\fi
+    }%
+  \fi
+}
+\begingroup\expandafter\expandafter\expandafter\endgroup
+\expandafter\ifx\csname KOMAClassName\endcsname\relax
+  \newtocstyle{KOMAlike}{%
+    \settocfeature{dothook}{\normalfont}%
+    \settocfeature[-1]{entryhook}{\sffamily\bfseries}%
+    \settocfeature[-1]{entryvskip}{2.25em\@plus\p@}%
+    \settocfeature[-1]{leaders}{\hfill}%
+    \settocfeature[-1]{pagenumberhook}{\sffamily\bfseries}%
+    \settocfeature[0]{entryvskip}{1em\@plus\p@}%
+    \settocfeature[0]{leaders}{\hfill}%
+    \settocfeature[0]{entryhook}{\sffamily\bfseries}
+    \settocfeature[0]{pagenumberhook}{\sffamily\bfseries}%
+    \iftochaschapter\else
+      \settocfeature[1]{entryvskip}{1em\@plus\p@}%
+      \settocfeature[1]{leaders}{\hfill}%
+      \settocfeature[1]{entryhook}{%
+        \ifx\tocstyleAliasTOC\ext@toc\sffamily\bfseries\fi
+      }%
+      \settocfeature[1]{pagenumberhook}{%
+        \ifx\tocstyleAliasTOC\ext@toc\sffamily\bfseries\fi
+      }%
+    \fi
+  }
+\else
+  \newtocstyle{KOMAlike}{%
+    \settocfeature{dothook}{\normalfont}%
+    \settocfeature[-1]{entryhook}{\usekomafont{partentry}}%
+    \settocfeature[-1]{entryvskip}{2.25em\@plus\p@}%
+    \settocfeature[-1]{leaders}{\hfill}%
+    \settocfeature[-1]{pagenumberhook}{\usekomafont{partentrypagenumber}}%
+    \settocfeature[0]{entryvskip}{1em\@plus\p@}%
+    \settocfeature[0]{leaders}{\hfill}%
+    \settocfeature[0]{entryhook}{\usekomafont{chapterentry}}%
+    \settocfeature[0]{pagenumberhook}{\usekomafont{chapterentrypagenumber}}%
+    \iftochaschapter\else
+      \settocfeature[1]{entryvskip}{1em\@plus\p@}%
+      \settocfeature[1]{leaders}{\hfill}%
+      \settocfeature[1]{entryhook}{%
+        \begingroup
+          \ifx\tocstyleAliasTOC\ext@toc
+            \def\@tempa{\endgroup\usekomafont{sectionentry}}%
+          \else
+            \let\@tempa\endgroup
+          \fi
+        \@tempa
+      }%
+      \settocfeature[1]{pagenumberhook}{%
+        \begingroup
+          \ifx\tocstyleAliasTOC\ext@toc
+            \def\@tempa{\endgroup\usekomafont{sectionentrypagenumber}}%
+          \else
+            \let\@tempa\endgroup
+          \fi
+        \@tempa
+      }%
+    \fi
+  }
+\fi
+\newcommand*{\tocstyle@deprecated@style@KOMAScript}{KOMAlike}%
+\newtocstyle[KOMAlike]{classic}{%
+  \settocfeature[-1]{pagenumberhook}{\normalfont\normalcolor}%
+  \settocfeature[0]{pagenumberhook}{\normalfont\normalcolor}%
+  \iftochaschapter\else
+    \settocfeature[1]{pagenumberhook}{\normalfont\normalcolor}%
+  \fi
+  \settocfeature{pagenumberhook}{\normalfont\normalcolor}%
+  \settocfeature{raggedhook}{\raggedright}%
+}
+\newtocstyle[classic][leaders]{allwithdot}{}
+\newtocstyle[allwithdot]{noonewithdot}{%
+  \settocfeature{leaders}{\hfill}%
+}
+\newtocstyle[classic][leaders]{nopagecolumn}{%
+  \settocfeature{leaders}{\quad}%
+  \settocfeature{parfillskip}{\z@ plus 1fil}%
+  \settocfeature{pagenumberbox}{\hbox}%
+}
+\InputIfFileExists{tocstyle.cfg}{%
+  \PackageInfo{tocstyle}{using tocstyle.cfg}%
+}{%
+  \PackageInfo{tocstyle}{no tocstyle.cfg found}%
+}
+\endinput
+%%
+%% End of file `tocstyle.sty'.


### PR DESCRIPTION
In issue #63 , I suggested to include tocstyle.sty in inputs folder. This will make the project compile without having to download the obsolete package and generate the .sty file.