### PR TITLE
Fix copy of .bst files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ install:
 	install -d $(INPUTS) $(DOC) $(BIB)
 	cp -R inputs/* $(INPUTS)
 	cp README.org COPYING CHANGELOG $(DOC)
+	cp -R inputs/* $(BIB)
 	@echo
 	@echo "Arquivos instalados com sucesso em $(INSTALLDIR)."
 	@echo


### PR DESCRIPTION
Changed the Makefile to make it copy the abntex2-alf.bst file to $(INSTALLDIR)/bibtex/bst.