### PR TITLE
Fix Makefile to copy .bst files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all:
 install:
 	install -d $(INPUTS) $(DOC) $(BIB)
 	cp -R inputs/* $(INPUTS)
+	cp -R inputs/*.bst $(BIB)
 	cp README.org COPYING CHANGELOG $(DOC)
 	@echo
 	@echo "Arquivos instalados com sucesso em $(INSTALLDIR)."


### PR DESCRIPTION
Changed the Makefile to make it copy the abntex2-alf.bst file to $(INSTALLDIR)/bibtex/bst.