### PR TITLE
Create the 'translatedabstract' environment

### DIFF
--- a/biblio/template_reproductions/modelodissertacao.tex
+++ b/biblio/template_reproductions/modelodissertacao.tex
@@ -50,6 +50,9 @@
 \title{
     Normas para apresentação de teses do Instituto de Informática e do PPGC
 }
+\translatedtitle{
+    Institute of Informatics and PPGC thesis submission guidelines
+}
 
 % Esta divisão que coloca "Silva" como sobrenome ao invés de "da Silva" não faz
 % muito sentido, mas reflete o modelo da biblioteca.
@@ -61,6 +64,10 @@
 \keyword{ABNT}
 \keyword{Processadores de Texto}
 \keyword{Formatação eletrônica de documentos}
+
+\translatedkeyword{ABNT}
+\translatedkeyword{Text processors}
+\translatedkeyword{Electronic document preparation}
 
 
 \begin{document}
@@ -94,12 +101,11 @@ O mesmo é recomendado para os próximos itens, até o Resumo e Abstract.
 \end{abstract}
 
 % Resumo em língua estrangeira.
-% Note a ordem dos parâmetros: título traduzido, palavras-chave traduzidas, e
-% o corpo do abstract.
-% As palavras-chave devem ser separadas por ponto, como manda o modelo.
-\begin{englishabstract}
-    {This should be in English}
-    {ABNT. Text processors. Electronic document preparation.}
+% O título na lingua estrangeira deve ser definido com \translatedtitle{...}
+% As palavras-chaves na língua estrangeira devem ser definidos como são
+% definidas para o idioma do documento, porém utilizando o comando
+% \translatedkeyword{...}
+\begin{translatedabstract}
     This manual has the purpose of [\ldots].
     Consiste na versão do resumo na língua vernácula para a língua estrangeira.
     As palavras chaves também devem ser traduzidas.
@@ -107,7 +113,7 @@ O mesmo é recomendado para os próximos itens, até o Resumo e Abstract.
     O abstract deve apresentar, adicionalmente, uma tradução do título do trabalho.
     O título traduzido é colocado antes do título do capítulo (“Abstract’”), a
     2 cm da margem superior, centralizado, em fonte Times New Roman, tamanho 12 e em negrito.
-\end{englishabstract}
+\end{translatedabstract}
 
 % A ordem dos elementos pré-textuais importa.
 \listoffigures
@@ -412,7 +418,7 @@ Destina-se à inclusão de informações complementares ao trabalho, mas que nã
 
 \chapter{Descrição do Anexo}
 
-Os anexos destinam-se à inclusão de material como cópias de artigos, manuais, etc., que não necessariamente precisam estar em conformidade com o modelo, e que não foram desenvolvidos pelo autor do trabalho. Nos anexos os números não precisam ser indicados, a não ser na página inicial de cada um. 
+Os anexos destinam-se à inclusão de material como cópias de artigos, manuais, etc., que não necessariamente precisam estar em conformidade com o modelo, e que não foram desenvolvidos pelo autor do trabalho. Nos anexos os números não precisam ser indicados, a não ser na página inicial de cada um.
 
 \chapter{Exemplo de Anexo}
 

--- a/exemplos/cic-tc.tex
+++ b/exemplos/cic-tc.tex
@@ -1,10 +1,10 @@
-% 
+%
 % exemplo genérico de uso da classe iiufrgs.cls
 % $Id: iiufrgs.tex,v 1.1.1.1 2005/01/18 23:54:42 avila Exp $
-% 
+%
 % This is an example file and is hereby explicitly put in the
 % public domain.
-% 
+%
 \documentclass[cic,tc]{iiufrgs}
 % Para usar o modelo, deve-se informar o programa e o tipo de documento.
 % Programas :
@@ -12,13 +12,13 @@
 % * ecp       -- Graduação em Ciência da Computação
 % * ppgc      -- Programa de Pós Graduação em Computação
 % * pgmigro   -- Programa de Pós Graduação em Microeletrônica
-% 
+%
 % Tipos de Documento:
 % * tc                -- Trabalhos de Conclusão (apenas cic e ecp)
 % * diss ou mestrado  -- Dissertações de Mestrado (ppgc e pgmicro)
 % * tese ou doutorado -- Teses de Doutorado (ppgc e pgmicro)
 % * ti                -- Trabalho Individual (ppgc e pgmicro)
-% 
+%
 % Outras Opções:
 % * english    -- para textos em inglês
 % * openright  -- Força início de capítulos em páginas ímpares (padrão da
@@ -39,10 +39,11 @@
 
 \usepackage[alf,abnt-emphasize=bf]{abntex2cite}	% pacote para usar citações abnt
 
-% 
+%
 % Informações gerais
-% 
+%
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{Using \LaTeX\ to Prepare Documents at II/UFRGS}
 
 \author{Flaumann}{Fritz Gutenberg}
 % alguns documentos podem ter varios autores:
@@ -96,20 +97,29 @@
 % \coord[Profa.~Dra.]{Weber}{Taisy da Silva} % coordenador do curso
 % \dept{INA}                                 % departamento relacionado
 
-% 
+%
 % palavras-chave
 % iniciar todas com letras minúsculas, exceto no caso de abreviaturas
-% 
+%
 \keyword{formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
+%
+% palavras-chave na lingua estrangeira
+% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+%
+\translatedkeyword{electronic document preparation}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
 %\settowidth{\seclen}{1.10~}
 
-% 
+%
 % inicio do documento
-% 
+%
 \begin{document}
 
 % folha de rosto
@@ -144,14 +154,12 @@
 \end{abstract}
 
 % resumo na outra língua
-% como parametros devem ser passados o titulo e as palavras-chave
-% na outra língua, separadas por vírgulas
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic document preparation. \LaTeX. ABNT. UFRGS}
-    This document is an example on how to prepare documents at II/UFRGS
-    using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
-    may serve as a guide for general-purpose commands. \emph{The text in
-      the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\begin{translatedabstract}
+This document is an example on how to prepare documents at II/UFRGS
+using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
+may serve as a guide for general-purpose commands. \emph{The text in
+the abstract should not contain more than 500~words.}
+\end{translatedabstract}
 
 % lista de figuras
 \listoffigures
@@ -195,14 +203,14 @@ A Figura~\ref{fig:ex1} representa o caso mais comum, onde a figura propriamente 
     \begin{center}
         % Aqui vai um includegraphics , um picture environment ou qualquer
         % outro comando necessário para incorporar o formato de imagem
-        % utilizado.        
+        % utilizado.
         \begin{picture}(100,100)
             \put(0,0){\line(0,1){100}}
             \put(0,0){\line(1,0){100}}
             \put(100,100){\line(0,-1){100}}
             \put(100,100){\line(-1,0){100}}
             \put(10,50){Uma Imagem}
-        \end{picture}    
+        \end{picture}
     \end{center}
     \label{fig:estrutura}
     \legend{Fonte: Os Autores}
@@ -319,7 +327,7 @@ Agora vamos fazer várias seções para termos valores de 2 dígitos no \content
 
 
 % e aqui vai a parte principal
-% 
+%
 % \chapter{Estado da arte}
 % \chapter{Mais estado da arte}
 % \chapter{A minha contribuição}
@@ -330,7 +338,7 @@ Agora vamos fazer várias seções para termos valores de 2 dígitos no \content
 % aqui será usado o environment padrao `thebibliography'; porém, sugere-se
 % seriamente o uso de BibTeX e do estilo abnt.bst (veja na página do
 % UTUG)
-% 
+%
 % observe também o estilo meio estranho de alguns labels; isso é
 % devido ao uso do pacote `natbib', que permite fazer citações de
 % autores, ano, e diversas combinações desses

--- a/exemplos/cic-tc.tex
+++ b/exemplos/cic-tc.tex
@@ -99,18 +99,18 @@
 
 %
 % palavras-chave
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas, exceto no caso de abreviaturas
 %
-\keyword{formatação eletrônica de documentos}
+\keyword{Formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
 %
 % palavras-chave na lingua estrangeira
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas, exceto no caso de abreviaturas
 %
-\translatedkeyword{electronic document preparation}
+\translatedkeyword{Electronic document preparation}
 \translatedkeyword{\LaTeX}
 \translatedkeyword{ABNT}
 \translatedkeyword{UFRGS}

--- a/exemplos/ecp-tc.tex
+++ b/exemplos/ecp-tc.tex
@@ -12,13 +12,13 @@
 %   * ecp       -- Graduação em Ciência da Computação
 %   * ppgc      -- Programa de Pós Graduação em Computação
 %   * pgmigro   -- Programa de Pós Graduação em Microeletrônica
-%   
+%
 % Tipos de Documento:
 %   * tc                -- Trabalhos de Conclusão (apenas cic e ecp)
 %   * diss ou mestrado  -- Dissertações de Mestrado (ppgc e pgmicro)
 %   * tese ou doutorado -- Teses de Doutorado (ppgc e pgmicro)
 %   * ti                -- Trabalho Individual (ppgc e pgmicro)
-% 
+%
 % Outras Opções:
 %   * english    -- para textos em inglês
 %   * openright  -- Força início de capítulos em páginas ímpares (padrão da
@@ -44,6 +44,7 @@
 % Informações gerais
 %
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{Using \LaTeX\ to Prepare Documents at II/UFRGS}
 
 \author{Flaumann}{Fritz Gutenberg}
 % alguns documentos podem ter varios autores:
@@ -107,6 +108,15 @@
 \keyword{UFRGS}
 
 %
+% palavras-chave na lingua estrangeira
+% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+%
+\translatedkeyword{electronic document preparation}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
+%
 % inicio do documento
 %
 \begin{document}
@@ -143,14 +153,12 @@ conter mais do que 500 palavras.}
 \end{abstract}
 
 % resumo na outra língua
-% como parametros devem ser passados o titulo e as palavras-chave
-% na outra língua, separadas por vírgulas
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic document preparation, \LaTeX, ABNT, UFRGS}
+\begin{translatedabstract}
 This document is an example on how to prepare documents at II/UFRGS
 using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
 may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\end{translatedabstract}
 
 % lista de abreviaturas e siglas
 % o parametro deve ser a abreviatura mais longa
@@ -270,7 +278,7 @@ O formato adotado pela ABNT prevê apenas três níveis (capítulo, seção e su
 A classe \emph{iiufrgs} faz uso do pacote \emph{abnTeX2} com algumas alterações
 feitas por Sandro Rama Fiorini. Culpe ele se algo der errado. Agradeça a ele
 pelo que der certo. As modificações dão uma camada de tinta NATBIB-style,
-já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços 
+já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços
 wtf. Exemplos de citação:
 
 \begin{itemize}
@@ -281,7 +289,7 @@ wtf. Exemplos de citação:
     \item \emph{citen or citenum}: Segundo \citen{Adams2009Conceptual},
         unicórnios são verdes.
     \item \emph{citeauthor e citeyearpar}: Segundo artigos de
-        \citeauthor{Adams2009Conceptual} , unicórnios são verdes 
+        \citeauthor{Adams2009Conceptual} , unicórnios são verdes
         \citeyearpar{Adams2009Conceptual}.
 
 \end{itemize}

--- a/exemplos/ecp-tc.tex
+++ b/exemplos/ecp-tc.tex
@@ -100,18 +100,18 @@
 
 %
 % palavras-chave
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\keyword{formatação eletrônica de documentos}
+\keyword{Formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
 %
 % palavras-chave na lingua estrangeira
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\translatedkeyword{electronic document preparation}
+\translatedkeyword{Electronic document preparation}
 \translatedkeyword{\LaTeX}
 \translatedkeyword{ABNT}
 \translatedkeyword{UFRGS}

--- a/exemplos/espec.tex
+++ b/exemplos/espec.tex
@@ -101,18 +101,18 @@
 
 %
 % palavras-chave
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\keyword{formatação eletrônica de documentos}
+\keyword{Formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
 %
 % palavras-chave na lingua estrangeira
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\translatedkeyword{electronic document preparation}
+\translatedkeyword{Electronic document preparation}
 \translatedkeyword{\LaTeX}
 \translatedkeyword{ABNT}
 \translatedkeyword{UFRGS}

--- a/exemplos/espec.tex
+++ b/exemplos/espec.tex
@@ -12,13 +12,13 @@
 %   * ecp       -- Graduação em Ciência da Computação
 %   * ppgc      -- Programa de Pós Graduação em Computação
 %   * pgmigro   -- Programa de Pós Graduação em Microeletrônica
-%   
+%
 % Tipos de Documento:
 %   * tc                -- Trabalhos de Conclusão (apenas cic e ecp)
 %   * diss ou mestrado  -- Dissertações de Mestrado (ppgc e pgmicro)
 %   * tese ou doutorado -- Teses de Doutorado (ppgc e pgmicro)
 %   * ti                -- Trabalho Individual (ppgc e pgmicro)
-% 
+%
 % Outras Opções:
 %   * english    -- para textos em inglês
 %   * openright  -- Força início de capítulos em páginas ímpares (padrão da
@@ -44,6 +44,7 @@
 % Informações gerais
 %
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{Using \LaTeX\ to Prepare Documents at II/UFRGS}
 \espec{Cachaça} % Curso de Especialização em Cachaça
 
 \author{Flaumann}{Fritz Gutenberg}
@@ -108,6 +109,15 @@
 \keyword{UFRGS}
 
 %
+% palavras-chave na lingua estrangeira
+% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+%
+\translatedkeyword{electronic document preparation}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
+%
 % inicio do documento
 %
 \begin{document}
@@ -144,14 +154,12 @@ conter mais do que 500 palavras.}
 \end{abstract}
 
 % resumo na outra língua
-% como parametros devem ser passados o titulo e as palavras-chave
-% na outra língua, separadas por vírgulas
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic document preparation, \LaTeX, ABNT, UFRGS}
+\begin{translatedabstract}
 This document is an example on how to prepare documents at II/UFRGS
 using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
 may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\end{translatedabstract}
 
 % lista de abreviaturas e siglas
 % o parametro deve ser a abreviatura mais longa
@@ -271,7 +279,7 @@ O formato adotado pela ABNT prevê apenas três níveis (capítulo, seção e su
 A classe \emph{iiufrgs} faz uso do pacote \emph{abnTeX2} com algumas alterações
 feitas por Sandro Rama Fiorini. Culpe ele se algo der errado. Agradeça a ele
 pelo que der certo. As modificações dão uma camada de tinta NATBIB-style,
-já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços 
+já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços
 wtf. Exemplos de citação:
 
 \begin{itemize}
@@ -282,7 +290,7 @@ wtf. Exemplos de citação:
     \item \emph{citen or citenum}: Segundo \citen{Adams2009Conceptual},
         unicórnios são verdes.
     \item \emph{citeauthor e citeyearpar}: Segundo artigos de
-        \citeauthor{Adams2009Conceptual} , unicórnios são verdes 
+        \citeauthor{Adams2009Conceptual} , unicórnios são verdes
         \citeyearpar{Adams2009Conceptual}.
 
 \end{itemize}

--- a/exemplos/exemplo_org2/dis.org
+++ b/exemplos/exemplo_org2/dis.org
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # -*- mode: org -*-
 
-#+TITLE: Exemplo Template UFRGS Dissertação 
+#+TITLE: Exemplo Template UFRGS Dissertação
 #+AUTHOR: Lucas Leandro Nesi
 #+EMAIL: lucas.nesi@inf.ufrgs.br
 #+DATE: Agosto@@latex:}{@@2020
@@ -30,6 +30,7 @@
 #+LATEX_HEADER: \renewcommand{\nominataCoordname}{Coordenadora do PPGC}
 
 #+LaTeX_HEADER: \keyword{HPC}
+#+LaTeX_HEADER: \translatedkeyword{HPC}
 
 
 * Main Text                                                        :ignore:
@@ -66,7 +67,7 @@
 
 #+LaTeX: \def\ACKLINE{\\}
 
-To my advisor, 
+To my advisor,
 *** Abstract                                                       :ignore:
 
 #+LaTeX: \begin{abstract}
@@ -74,10 +75,10 @@ To my advisor,
 Something
 #+LaTeX: \end{abstract}
 
-#+LaTeX: \begin{englishabstract}{}{Palavra Chave 1, 2, 3}
+#+LaTeX: \begin{translatedabstract}
 Alguma coisa
 
-#+LaTeX: \end{englishabstract}
+#+LaTeX: \end{translatedabstract}
 
 *** Lists                                                          :ignore:
 #+BEGIN_EXPORT latex
@@ -177,7 +178,7 @@ Tangle this file with C-c C-v t
 # eval: (add-to-list 'org-latex-classes
 #             '("IIUFRGS"
 #               "\\documentclass{iiufrgs}" ; São permitidas subdivisões até o 5º nível (onde o capítulo é o 1º nível)
-#               ("\\chapter{%s}" . "\\chapter*{%s}")  
+#               ("\\chapter{%s}" . "\\chapter*{%s}")
 #               ("\\section{%s}" . "\\section*{%s}")
 #               ("\\subsection{%s}" . "\\subsection*{%s}")
 #               ("\\subsubsection{%s}" . "\\subsubsection*{%s}")

--- a/exemplos/iiufrgs.tex
+++ b/exemplos/iiufrgs.tex
@@ -97,18 +97,18 @@
 
 %
 % palavras-chave
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\keyword{formatação eletrônica de documentos}
+\keyword{Formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
 %
 % palavras-chave na lingua estrangeira
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\translatedkeyword{electronic document preparation}
+\translatedkeyword{Electronic document preparation}
 \translatedkeyword{\LaTeX}
 \translatedkeyword{ABNT}
 \translatedkeyword{UFRGS}

--- a/exemplos/iiufrgs.tex
+++ b/exemplos/iiufrgs.tex
@@ -25,6 +25,7 @@
 % Informações gerais
 %
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{Using \LaTeX\ to Prepare Documents at II/UFRGS}
 
 \author{Flaumann}{Fritz Gutenberg}
 % alguns documentos podem ter varios autores:
@@ -104,6 +105,15 @@
 \keyword{UFRGS}
 
 %
+% palavras-chave na lingua estrangeira
+% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+%
+\translatedkeyword{electronic document preparation}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
+%
 % inicio do documento
 %
 \begin{document}
@@ -163,14 +173,12 @@ conter mais do que 500 palavras.}
 \end{abstract}
 
 % resumo na outra língua
-% como parametros devem ser passados o titulo e as palavras-chave
-% na outra língua, separadas por vírgulas
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic document preparation, \LaTeX, ABNT, UFRGS}
+\begin{translatedabstract}
 This document is an example on how to prepare documents at II/UFRGS
 using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
 may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\end{translatedabstract}
 
 % aqui comeca o texto propriamente dito
 
@@ -249,7 +257,7 @@ completa de autores (ex.~``[\ldots] na linguagem Panda~\citep*{Assenmacher:Panda
 \bibitem[ANDREWS, 1991]{Andrews:CP-91} ANDREWS,
   G.~R\@. \textbf{Concurrent programming}: principles and
   practice. Redwood~City, USA: Benjamin/Cummings, 1991. 637p.
-  
+
 \bibitem[ASSENMACHER et~al.(1993)ASSENMACHER; BREITBACH; BUHLER;
   H{\"U}BSCH; SCHWARZ]{Assenmacher:Panda-ECOOP93} ASSENMACHER, H.;
   BREITBACH, T.; BUHLER, P.; H{\"U}BSCH, V.; SCHWARZ, R\@.

--- a/exemplos/latexmk/diss.tex
+++ b/exemplos/latexmk/diss.tex
@@ -76,6 +76,7 @@
 % Informações gerais
 %
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{Using \LaTeX\ to Prepare Documents at II/UFRGS}
 
 \author{Flaumann}{Fritz Gutenberg}
 % alguns documentos podem ter varios autores:
@@ -139,6 +140,15 @@
 \keyword{UFRGS}
 
 %
+% palavras-chave na lingua estrangeira
+% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+%
+\translatedkeyword{electronic document preparation}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
+%
 % inicio do documento
 %
 \begin{document}
@@ -179,14 +189,12 @@ conter mais do que 500 palavras.}
 \end{abstract}
 
 % resumo na outra língua
-% como parametros devem ser passados o titulo e as palavras-chave
-% na outra língua, separadas por vírgulas
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic document preparation. \LaTeX. ABNT. UFRGS}
+\begin{translatedabstract}
 This document is an example on how to prepare documents at II/UFRGS
 using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
 may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\end{translatedabstract}
 
 % lista de abreviaturas e siglas
 % o parametro deve ser a abreviatura mais longa

--- a/exemplos/latexmk/diss.tex
+++ b/exemplos/latexmk/diss.tex
@@ -132,18 +132,18 @@
 
 %
 % palavras-chave
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\keyword{formatação eletrônica de documentos}
+\keyword{Formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
 %
 % palavras-chave na lingua estrangeira
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\translatedkeyword{electronic document preparation}
+\translatedkeyword{Electronic document preparation}
 \translatedkeyword{\LaTeX}
 \translatedkeyword{ABNT}
 \translatedkeyword{UFRGS}

--- a/exemplos/org/prop.org
+++ b/exemplos/org/prop.org
@@ -16,6 +16,8 @@
 #+OPTIONS: ^:nil _:nil
 #+OPTIONS: ':t toc:nil
 
+#+LATEX_HEADER: \translatedtitle{II-UFRGS example document using ORG-Mode}
+
 ** ORG Functions -- no export                                     :noexport:
 
 #+NAME: org_include_graphics
@@ -82,6 +84,11 @@ E pelo M-x butterfly
 \keyword{kw1}
 \keyword{kw2}
 
+# Tags no segundo idioma do documento
+
+\translatedkeyword{kw1}
+\translatedkeyword{kw2}
+
 #+ATTR_LATEX:
 #+BEGIN_abstract
 The abstract.
@@ -93,12 +100,12 @@ If you're writing in english, this is the abstract in english
 
 * English Abstract                                                   :ignore:
 
-#+ATTR_LATEX: :options {The Title}{kw1, kw2, kw3}
-#+BEGIN_englishabstract
+#+ATTR_LATEX:
+#+BEGIN_translatedabstract
 The abstract text in english!
 
 *IMPORTANT NOTE*: If you're writing in english, than this becomes the "Resumo" in portuguese
-#+END_englishabstract
+#+END_translatedabstract
 
 * Abreviaturas                                                       :ignore:
 

--- a/exemplos/pgmicro-diss.tex
+++ b/exemplos/pgmicro-diss.tex
@@ -12,13 +12,13 @@
 %   * ecp       -- Graduação em Ciência da Computação
 %   * ppgc      -- Programa de Pós Graduação em Computação
 %   * pgmigro   -- Programa de Pós Graduação em Microeletrônica
-%   
+%
 % Tipos de Documento:
 %   * tc                -- Trabalhos de Conclusão (apenas cic e ecp)
 %   * diss ou mestrado  -- Dissertações de Mestrado (ppgc e pgmicro)
 %   * tese ou doutorado -- Teses de Doutorado (ppgc e pgmicro)
 %   * ti                -- Trabalho Individual (ppgc e pgmicro)
-% 
+%
 % Outras Opções:
 %   * english    -- para textos em inglês
 %   * openright  -- Força início de capítulos em páginas ímpares (padrão da
@@ -44,6 +44,7 @@
 % Informações gerais
 %
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{Using \LaTeX\ to Prepare Documents at II/UFRGS}
 
 \author{Flaumann}{Fritz Gutenberg}
 % alguns documentos podem ter varios autores:
@@ -107,6 +108,15 @@
 \keyword{UFRGS}
 
 %
+% palavras-chave na lingua estrangeira
+% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+%
+\translatedkeyword{electronic document preparation}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
+%
 % inicio do documento
 %
 \begin{document}
@@ -143,14 +153,12 @@ conter mais do que 500 palavras.}
 \end{abstract}
 
 % resumo na outra língua
-% como parametros devem ser passados o titulo e as palavras-chave
-% na outra língua, separadas por vírgulas
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic document preparation, \LaTeX, ABNT, UFRGS}
+\begin{translatedabstract}
 This document is an example on how to prepare documents at II/UFRGS
 using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
 may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\end{translatedabstract}
 
 % lista de abreviaturas e siglas
 % o parametro deve ser a abreviatura mais longa
@@ -270,7 +278,7 @@ O formato adotado pela ABNT prevê apenas três níveis (capítulo, seção e su
 A classe \emph{iiufrgs} faz uso do pacote \emph{abnTeX2} com algumas alterações
 feitas por Sandro Rama Fiorini. Culpe ele se algo der errado. Agradeça a ele
 pelo que der certo. As modificações dão uma camada de tinta NATBIB-style,
-já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços 
+já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços
 wtf. Exemplos de citação:
 
 \begin{itemize}
@@ -281,7 +289,7 @@ wtf. Exemplos de citação:
     \item \emph{citen or citenum}: Segundo \citen{Adams2009Conceptual},
         unicórnios são verdes.
     \item \emph{citeauthor e citeyearpar}: Segundo artigos de
-        \citeauthor{Adams2009Conceptual} , unicórnios são verdes 
+        \citeauthor{Adams2009Conceptual} , unicórnios são verdes
         \citeyearpar{Adams2009Conceptual}.
 
 \end{itemize}

--- a/exemplos/pgmicro-diss.tex
+++ b/exemplos/pgmicro-diss.tex
@@ -100,18 +100,18 @@
 
 %
 % palavras-chave
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\keyword{formatação eletrônica de documentos}
+\keyword{Formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
 %
 % palavras-chave na lingua estrangeira
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\translatedkeyword{electronic document preparation}
+\translatedkeyword{Electronic document preparation}
 \translatedkeyword{\LaTeX}
 \translatedkeyword{ABNT}
 \translatedkeyword{UFRGS}

--- a/exemplos/pgmicro-tese.tex
+++ b/exemplos/pgmicro-tese.tex
@@ -12,13 +12,13 @@
 %   * ecp       -- Graduação em Ciência da Computação
 %   * ppgc      -- Programa de Pós Graduação em Computação
 %   * pgmigro   -- Programa de Pós Graduação em Microeletrônica
-%   
+%
 % Tipos de Documento:
 %   * tc                -- Trabalhos de Conclusão (apenas cic e ecp)
 %   * diss ou mestrado  -- Dissertações de Mestrado (ppgc e pgmicro)
 %   * tese ou doutorado -- Teses de Doutorado (ppgc e pgmicro)
 %   * ti                -- Trabalho Individual (ppgc e pgmicro)
-% 
+%
 % Outras Opções:
 %   * english    -- para textos em inglês
 %   * openright  -- Força início de capítulos em páginas ímpares (padrão da
@@ -44,6 +44,7 @@
 % Informações gerais
 %
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{Using \LaTeX\ to Prepare Documents at II/UFRGS}
 
 \author{Flaumann}{Fritz Gutenberg}
 % alguns documentos podem ter varios autores:
@@ -107,6 +108,15 @@
 \keyword{UFRGS}
 
 %
+% palavras-chave na lingua estrangeira
+% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+%
+\translatedkeyword{electronic document preparation}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
+%
 % inicio do documento
 %
 \begin{document}
@@ -143,14 +153,12 @@ conter mais do que 500 palavras.}
 \end{abstract}
 
 % resumo na outra língua
-% como parametros devem ser passados o titulo e as palavras-chave
-% na outra língua, separadas por vírgulas
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic document preparation, \LaTeX, ABNT, UFRGS}
+\begin{translatedabstract}
 This document is an example on how to prepare documents at II/UFRGS
 using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
 may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\end{translatedabstract}
 
 % lista de abreviaturas e siglas
 % o parametro deve ser a abreviatura mais longa
@@ -270,7 +278,7 @@ O formato adotado pela ABNT prevê apenas três níveis (capítulo, seção e su
 A classe \emph{iiufrgs} faz uso do pacote \emph{abnTeX2} com algumas alterações
 feitas por Sandro Rama Fiorini. Culpe ele se algo der errado. Agradeça a ele
 pelo que der certo. As modificações dão uma camada de tinta NATBIB-style,
-já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços 
+já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços
 wtf. Exemplos de citação:
 
 \begin{itemize}
@@ -281,7 +289,7 @@ wtf. Exemplos de citação:
     \item \emph{citen or citenum}: Segundo \citen{Adams2009Conceptual},
         unicórnios são verdes.
     \item \emph{citeauthor e citeyearpar}: Segundo artigos de
-        \citeauthor{Adams2009Conceptual} , unicórnios são verdes 
+        \citeauthor{Adams2009Conceptual} , unicórnios são verdes
         \citeyearpar{Adams2009Conceptual}.
 
 \end{itemize}

--- a/exemplos/pgmicro-tese.tex
+++ b/exemplos/pgmicro-tese.tex
@@ -100,18 +100,18 @@
 
 %
 % palavras-chave
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\keyword{formatação eletrônica de documentos}
+\keyword{Formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
 %
 % palavras-chave na lingua estrangeira
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\translatedkeyword{electronic document preparation}
+\translatedkeyword{Electronic document preparation}
 \translatedkeyword{\LaTeX}
 \translatedkeyword{ABNT}
 \translatedkeyword{UFRGS}

--- a/exemplos/ppgc-diss.tex
+++ b/exemplos/ppgc-diss.tex
@@ -12,13 +12,13 @@
 %   * ecp       -- Graduação em Ciência da Computação
 %   * ppgc      -- Programa de Pós Graduação em Computação
 %   * pgmigro   -- Programa de Pós Graduação em Microeletrônica
-%   
+%
 % Tipos de Documento:
 %   * tc                -- Trabalhos de Conclusão (apenas cic e ecp)
 %   * diss ou mestrado  -- Dissertações de Mestrado (ppgc e pgmicro)
 %   * tese ou doutorado -- Teses de Doutorado (ppgc e pgmicro)
 %   * ti                -- Trabalho Individual (ppgc e pgmicro)
-% 
+%
 % Outras Opções:
 %   * english    -- para textos em inglês
 %   * openright  -- Força início de capítulos em páginas ímpares (padrão da
@@ -44,6 +44,7 @@
 % Informações gerais
 %
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{Using \LaTeX\ to Prepare Documents at II/UFRGS}
 
 \author{Flaumann}{Fritz Gutenberg}
 % alguns documentos podem ter varios autores:
@@ -107,6 +108,16 @@
 \keyword{UFRGS}
 
 %
+% palavras-chave na lingua estrangeira
+% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+%
+\translatedkeyword{electronic document preparation}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
+
+%
 % inicio do documento
 %
 \begin{document}
@@ -143,14 +154,12 @@ conter mais do que 500 palavras.}
 \end{abstract}
 
 % resumo na outra língua
-% como parametros devem ser passados o titulo e as palavras-chave
-% na outra língua, separadas por vírgulas
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic document preparation, \LaTeX, ABNT, UFRGS}
+\begin{translatedabstract}
 This document is an example on how to prepare documents at II/UFRGS
 using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
 may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\end{translatedabstract}
 
 % lista de abreviaturas e siglas
 % o parametro deve ser a abreviatura mais longa
@@ -270,7 +279,7 @@ O formato adotado pela ABNT prevê apenas três níveis (capítulo, seção e su
 A classe \emph{iiufrgs} faz uso do pacote \emph{abnTeX2} com algumas alterações
 feitas por Sandro Rama Fiorini. Culpe ele se algo der errado. Agradeça a ele
 pelo que der certo. As modificações dão uma camada de tinta NATBIB-style,
-já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços 
+já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços
 wtf. Exemplos de citação:
 
 \begin{itemize}
@@ -281,7 +290,7 @@ wtf. Exemplos de citação:
     \item \emph{citen or citenum}: Segundo \citen{Adams2009Conceptual},
         unicórnios são verdes.
     \item \emph{citeauthor e citeyearpar}: Segundo artigos de
-        \citeauthor{Adams2009Conceptual} , unicórnios são verdes 
+        \citeauthor{Adams2009Conceptual} , unicórnios são verdes
         \citeyearpar{Adams2009Conceptual}.
 
 \end{itemize}

--- a/exemplos/ppgc-diss.tex
+++ b/exemplos/ppgc-diss.tex
@@ -100,18 +100,18 @@
 
 %
 % palavras-chave
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\keyword{formatação eletrônica de documentos}
+\keyword{Formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
 %
 % palavras-chave na lingua estrangeira
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\translatedkeyword{electronic document preparation}
+\translatedkeyword{Electronic document preparation}
 \translatedkeyword{\LaTeX}
 \translatedkeyword{ABNT}
 \translatedkeyword{UFRGS}

--- a/exemplos/ppgc-tese.tex
+++ b/exemplos/ppgc-tese.tex
@@ -12,13 +12,13 @@
 %   * ecp       -- Graduação em Ciência da Computação
 %   * ppgc      -- Programa de Pós Graduação em Computação
 %   * pgmigro   -- Programa de Pós Graduação em Microeletrônica
-%   
+%
 % Tipos de Documento:
 %   * tc                -- Trabalhos de Conclusão (apenas cic e ecp)
 %   * diss ou mestrado  -- Dissertações de Mestrado (ppgc e pgmicro)
 %   * tese ou doutorado -- Teses de Doutorado (ppgc e pgmicro)
 %   * ti                -- Trabalho Individual (ppgc e pgmicro)
-% 
+%
 % Outras Opções:
 %   * english    -- para textos em inglês
 %   * openright  -- Força início de capítulos em páginas ímpares (padrão da
@@ -44,6 +44,7 @@
 % Informações gerais
 %
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{An Example of a Monograph from the Informatics Institute of UFRGS}
 
 \author{Flaumann}{Fritz Gutenberg}
 % alguns documentos podem ter varios autores:
@@ -111,6 +112,19 @@
 \keyword{UFRGS}
 
 %
+% palavras-chave na lingua estrangeira
+% A primeira palavra de cada palavra-chave (que, ironicamente, pode ser várias palavras) deve sempre
+% começar em maíuscula (novo padrão da biblioteca), as demais palavras começam em minúscula, exceto
+% se são nomes próprios. Nomes próprios não dvem ser traduzidos.
+%
+\translatedkeyword{Electronic document preparation}
+\translatedkeyword{Document standardization}
+\translatedkeyword{Instituto de Informática da UFRGS}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
+%
 % inicio do documento
 %
 \begin{document}
@@ -146,19 +160,13 @@ para comandos mais genéricos. \emph{O texto do resumo não deve
 conter mais do que 500 palavras.}
 \end{abstract}
 
-% Resumo na outra língua, se o documento estiver em português, esse estará em inglês,
-% se o documento estiver em inglês, este deve estar em português.
-% Devem ser passados como parâmetros: o título e as palavras-chave
-% na outra língua, separadas por pontos, sem ponto após a última palavra-chave.
-% O mesmo padrão de capitalizar a primeira palavra de cada palavra-chave deve ser seguido aqui.
-% Seguindo a ideia de não traduzir nomes próprios, nem UFRGS, nem ABNT, nem "Instituto de Informática
-% da UFRGS" são traduzidos.
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic formatting of documents. Instituto de Informática da UFRGS. \LaTeX. ABNT. UFRGS}
+% resumo na outra língua
+\begin{translatedabstract}
 This document is an example on how to prepare documents at II/UFRGS
 using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
 may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\end{translatedabstract}
 
 % lista de figuras
 \listoffigures
@@ -280,7 +288,7 @@ O formato adotado pela ABNT prevê apenas três níveis (capítulo, seção e su
 A classe \emph{iiufrgs} faz uso do pacote \emph{abnTeX2} com algumas alterações
 feitas por Sandro Rama Fiorini. Culpe ele se algo der errado. Agradeça a ele
 pelo que der certo. As modificações dão uma camada de tinta NATBIB-style,
-já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços 
+já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços
 wtf. Exemplos de citação:
 
 \begin{itemize}
@@ -291,7 +299,7 @@ wtf. Exemplos de citação:
     \item \emph{citen or citenum}: Segundo \citen{Adams2009Conceptual},
         unicórnios são verdes.
     \item \emph{citeauthor e citeyearpar}: Segundo artigos de
-        \citeauthor{Adams2009Conceptual} , unicórnios são verdes 
+        \citeauthor{Adams2009Conceptual} , unicórnios são verdes
         \citeyearpar{Adams2009Conceptual}.
 
 \end{itemize}

--- a/exemplos/ti.tex
+++ b/exemplos/ti.tex
@@ -12,13 +12,13 @@
 %   * ecp       -- Graduação em Ciência da Computação
 %   * ppgc      -- Programa de Pós Graduação em Computação
 %   * pgmigro   -- Programa de Pós Graduação em Microeletrônica
-%   
+%
 % Tipos de Documento:
 %   * tc                -- Trabalhos de Conclusão (apenas cic e ecp)
 %   * diss ou mestrado  -- Dissertações de Mestrado (ppgc e pgmicro)
 %   * tese ou doutorado -- Teses de Doutorado (ppgc e pgmicro)
 %   * ti                -- Trabalho Individual (ppgc e pgmicro)
-% 
+%
 % Outras Opções:
 %   * english    -- para textos em inglês
 %   * openright  -- Força início de capítulos em páginas ímpares (padrão da
@@ -44,6 +44,7 @@
 % Informações gerais
 %
 \title{Um Exemplo de Monografia do Instituto de Informática da UFRGS}
+\translatedtitle{Using \LaTeX\ to Prepare Documents at II/UFRGS}
 
 \author{Flaumann}{Fritz Gutenberg}
 % alguns documentos podem ter varios autores:
@@ -107,6 +108,15 @@
 \keyword{UFRGS}
 
 %
+% palavras-chave na lingua estrangeira
+% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+%
+\translatedkeyword{electronic document preparation}
+\translatedkeyword{\LaTeX}
+\translatedkeyword{ABNT}
+\translatedkeyword{UFRGS}
+
+%
 % inicio do documento
 %
 \begin{document}
@@ -143,14 +153,12 @@ conter mais do que 500 palavras.}
 \end{abstract}
 
 % resumo na outra língua
-% como parametros devem ser passados o titulo e as palavras-chave
-% na outra língua, separadas por vírgulas
-\begin{englishabstract}{Using \LaTeX\ to Prepare Documents at II/UFRGS}{Electronic document preparation, \LaTeX, ABNT, UFRGS}
+\begin{translatedabstract}
 This document is an example on how to prepare documents at II/UFRGS
 using the \LaTeX\ classes provided by the UTUG\@. At the same time, it
 may serve as a guide for general-purpose commands. \emph{The text in
 the abstract should not contain more than 500~words.}
-\end{englishabstract}
+\end{translatedabstract}
 
 % lista de abreviaturas e siglas
 % o parametro deve ser a abreviatura mais longa
@@ -270,7 +278,7 @@ O formato adotado pela ABNT prevê apenas três níveis (capítulo, seção e su
 A classe \emph{iiufrgs} faz uso do pacote \emph{abnTeX2} com algumas alterações
 feitas por Sandro Rama Fiorini. Culpe ele se algo der errado. Agradeça a ele
 pelo que der certo. As modificações dão uma camada de tinta NATBIB-style,
-já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços 
+já que o abntex2 usa uns comandos de citação feitos para alienígenas de 5 braços
 wtf. Exemplos de citação:
 
 \begin{itemize}
@@ -281,7 +289,7 @@ wtf. Exemplos de citação:
     \item \emph{citen or citenum}: Segundo \citen{Adams2009Conceptual},
         unicórnios são verdes.
     \item \emph{citeauthor e citeyearpar}: Segundo artigos de
-        \citeauthor{Adams2009Conceptual} , unicórnios são verdes 
+        \citeauthor{Adams2009Conceptual} , unicórnios são verdes
         \citeyearpar{Adams2009Conceptual}.
 
 \end{itemize}

--- a/exemplos/ti.tex
+++ b/exemplos/ti.tex
@@ -100,18 +100,18 @@
 
 %
 % palavras-chave
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\keyword{formatação eletrônica de documentos}
+\keyword{Formatação eletrônica de documentos}
 \keyword{\LaTeX}
 \keyword{ABNT}
 \keyword{UFRGS}
 
 %
 % palavras-chave na lingua estrangeira
-% iniciar todas com letras minúsculas, exceto no caso de abreviaturas
+% iniciar todas com letras maiúsculas
 %
-\translatedkeyword{electronic document preparation}
+\translatedkeyword{Electronic document preparation}
 \translatedkeyword{\LaTeX}
 \translatedkeyword{ABNT}
 \translatedkeyword{UFRGS}

--- a/inputs/iiufrgs.cls
+++ b/inputs/iiufrgs.cls
@@ -230,6 +230,27 @@
 }
 
 %==============================================================================
+% Definição das palavras-chave no segundo idioma (máx. 10)
+%==============================================================================
+\newcounter{translatedkwcounter}
+\newcommand{\translatedkeyword}[1]{
+        \addtocounter{translatedkwcounter}{1}
+        \expandafter\gdef\csname translatedkeyw\alph{translatedkwcounter}\endcsname{#1}
+}
+\newcommand{\@translatedabstractkw}{%
+        \@ifundefined{translatedkeywa}{}{\expandafter\MakeUppercase\translatedkeywa}%
+        \@ifundefined{translatedkeywb}{}{. \translatedkeywb}%
+        \@ifundefined{translatedkeywc}{}{. \translatedkeywc}%
+        \@ifundefined{translatedkeywd}{}{. \translatedkeywd}%
+        \@ifundefined{translatedkeywe}{}{. \translatedkeywe}%
+        \@ifundefined{translatedkeywf}{}{. \translatedkeywf}%
+        \@ifundefined{translatedkeywg}{}{. \translatedkeywg}%
+        \@ifundefined{translatedkeywh}{}{. \translatedkeywh}%
+        \@ifundefined{translatedkeywi}{}{. \translatedkeywi}%
+        \@ifundefined{translatedkeywj}{}{. \translatedkeywj}%
+}
+
+%==============================================================================
 % Redefinição da data (para ter mês e ano separados)
 %==============================================================================
 \renewcommand{\date}[2]{
@@ -501,6 +522,36 @@
   \vspace{12pt}
 
   \noindent\textbf{\keywordsname:} \@englishkeywords.
+\end{otherlanguage}
+}
+
+%==============================================================================
+% Definição do título traduzido no segundo idioma
+%==============================================================================
+\newcommand{\translatedtitle}[1]{%
+    \gdef\@translatedtitle{#1}%
+}%
+
+%==============================================================================
+% Translated Abstract
+%==============================================================================
+\newenvironment{translatedabstract}[0]{%
+        \if@openright\cleardoublepage\else\clearpage\fi%
+        \iflanguage{english}{
+                \begin{otherlanguage}{brazilian}
+        }{
+                \begin{otherlanguage}{english}
+        }
+        \begin{center}%
+            \textbf{\@ifundefined{@translatedtitle}{\@title}{\@translatedtitle}}%
+            \vspace{12pt}
+        \end{center}
+
+        \samepagechapter*{\abstractname}\setlength{\parindent}{0pt}
+}{%
+  \vspace{12pt}
+
+  \noindent\textbf{\keywordsname:} \@translatedabstractkw.
 \end{otherlanguage}
 }
 

--- a/inputs/iiufrgs.cls
+++ b/inputs/iiufrgs.cls
@@ -495,7 +495,7 @@
 }
 
 %==============================================================================
-% Resumo (abstract) e Abstract (englishabstract)
+% Resumo (abstract) e Abstract (translatedabstract)
 %==============================================================================
 \renewenvironment{abstract}{%
         \chapter*{\abstractname}\setlength{\parindent}{0pt}
@@ -505,6 +505,35 @@
     \vspace{\parskip}\noindent\textbf{\keywordsname:} \@abstractkw.
 }
 
+\newenvironment{translatedabstract}[0]{%
+    \if@openright\cleardoublepage\else\clearpage\fi%
+    \iflanguage{english}{
+        \begin{otherlanguage}{brazilian}
+    }{
+        \begin{otherlanguage}{english}
+    }
+    \@ifundefined{@translatedtitle}{%
+        \PackageWarningNoLine{iiufrgs}{Translated title not defined. Use the translatedtitle command to define it}
+    }{%
+        \begin{center}%
+            \textbf{\@translatedtitle}%
+            \vspace{12pt}
+        \end{center}
+    }
+    \samepagechapter*{\abstractname}\setlength{\parindent}{0pt}
+}{%
+    \ifnum\value{translatedkwcounter}>0
+        \vspace{12pt}
+
+        \noindent\textbf{\keywordsname:} \@translatedabstractkw.
+    \else
+        \PackageWarningNoLine{iiufrgs}{No translated keyword has been defined. Use
+        the translatedkeyword command to define them.}
+    \fi
+    \end{otherlanguage}
+}
+
+% Deprecated
 \newenvironment{englishabstract}[2]{%
         \PackageWarning{iiufrgs}{The 'englishabstract' is deprecated, use 'translatedabstract'
         instead (https://github.com/schnorr/infufrgs/pull/80)}
@@ -533,29 +562,6 @@
 \newcommand{\translatedtitle}[1]{%
     \gdef\@translatedtitle{#1}%
 }%
-
-%==============================================================================
-% Translated Abstract
-%==============================================================================
-\newenvironment{translatedabstract}[0]{%
-        \if@openright\cleardoublepage\else\clearpage\fi%
-        \iflanguage{english}{
-                \begin{otherlanguage}{brazilian}
-        }{
-                \begin{otherlanguage}{english}
-        }
-        \begin{center}%
-            \textbf{\@ifundefined{@translatedtitle}{\@title}{\@translatedtitle}}%
-            \vspace{12pt}
-        \end{center}
-
-        \samepagechapter*{\abstractname}\setlength{\parindent}{0pt}
-}{%
-  \vspace{12pt}
-
-  \noindent\textbf{\keywordsname:} \@translatedabstractkw.
-\end{otherlanguage}
-}
 
 
 %==============================================================================

--- a/inputs/iiufrgs.cls
+++ b/inputs/iiufrgs.cls
@@ -506,6 +506,8 @@
 }
 
 \newenvironment{englishabstract}[2]{%
+        \PackageWarning{iiufrgs}{The 'englishabstract' is deprecated, use 'translatedabstract'
+        instead (https://github.com/schnorr/infufrgs/pull/80)}
         \if@openright\cleardoublepage\else\clearpage\fi%
         \gdef\@englishkeywords{#2}%
         \iflanguage{english}{

--- a/inputs/iiufrgs.cls
+++ b/inputs/iiufrgs.cls
@@ -217,16 +217,16 @@
         \@ifundefined{keywj}{}{10.~\expandafter\MakeUppercase\keywj\@. }%
 }
 \newcommand{\@abstractkw}{%
-        \@ifundefined{keywa}{}{\expandafter\MakeUppercase\keywa}%
-        \@ifundefined{keywb}{}{. \keywb}%
-        \@ifundefined{keywc}{}{. \keywc}%
-        \@ifundefined{keywd}{}{. \keywd}%
-        \@ifundefined{keywe}{}{. \keywe}%
-        \@ifundefined{keywf}{}{. \keywf}%
-        \@ifundefined{keywg}{}{. \keywg}%
-        \@ifundefined{keywh}{}{. \keywh}%
-        \@ifundefined{keywi}{}{. \keywi}%
-        \@ifundefined{keywj}{}{. \keywj}%
+        \@ifundefined{keywa}{}{\keywa.}%
+        \@ifundefined{keywb}{}{ \keywb.}%
+        \@ifundefined{keywc}{}{ \keywc.}%
+        \@ifundefined{keywd}{}{ \keywd.}%
+        \@ifundefined{keywe}{}{ \keywe.}%
+        \@ifundefined{keywf}{}{ \keywf.}%
+        \@ifundefined{keywg}{}{ \keywg.}%
+        \@ifundefined{keywh}{}{ \keywh.}%
+        \@ifundefined{keywi}{}{ \keywi.}%
+        \@ifundefined{keywj}{}{ \keywj.}%
 }
 
 %==============================================================================
@@ -238,16 +238,16 @@
         \expandafter\gdef\csname translatedkeyw\alph{translatedkwcounter}\endcsname{#1}
 }
 \newcommand{\@translatedabstractkw}{%
-        \@ifundefined{translatedkeywa}{}{\expandafter\MakeUppercase\translatedkeywa}%
-        \@ifundefined{translatedkeywb}{}{. \translatedkeywb}%
-        \@ifundefined{translatedkeywc}{}{. \translatedkeywc}%
-        \@ifundefined{translatedkeywd}{}{. \translatedkeywd}%
-        \@ifundefined{translatedkeywe}{}{. \translatedkeywe}%
-        \@ifundefined{translatedkeywf}{}{. \translatedkeywf}%
-        \@ifundefined{translatedkeywg}{}{. \translatedkeywg}%
-        \@ifundefined{translatedkeywh}{}{. \translatedkeywh}%
-        \@ifundefined{translatedkeywi}{}{. \translatedkeywi}%
-        \@ifundefined{translatedkeywj}{}{. \translatedkeywj}%
+        \@ifundefined{translatedkeywa}{}{\translatedkeywa.}%
+        \@ifundefined{translatedkeywb}{}{ \translatedkeywb.}%
+        \@ifundefined{translatedkeywc}{}{ \translatedkeywc.}%
+        \@ifundefined{translatedkeywd}{}{ \translatedkeywd.}%
+        \@ifundefined{translatedkeywe}{}{ \translatedkeywe.}%
+        \@ifundefined{translatedkeywf}{}{ \translatedkeywf.}%
+        \@ifundefined{translatedkeywg}{}{ \translatedkeywg.}%
+        \@ifundefined{translatedkeywh}{}{ \translatedkeywh.}%
+        \@ifundefined{translatedkeywi}{}{ \translatedkeywi.}%
+        \@ifundefined{translatedkeywj}{}{ \translatedkeywj.}%
 }
 
 %==============================================================================
@@ -502,7 +502,7 @@
 }{%
     %\par\vfill
     \\
-    \vspace{\parskip}\noindent\textbf{\keywordsname:} \@abstractkw.
+    \vspace{\parskip}\noindent\textbf{\keywordsname:} \@abstractkw
 }
 
 \newenvironment{translatedabstract}[0]{%
@@ -525,7 +525,7 @@
     \ifnum\value{translatedkwcounter}>0
         \vspace{12pt}
 
-        \noindent\textbf{\keywordsname:} \@translatedabstractkw.
+        \noindent\textbf{\keywordsname:} \@translatedabstractkw
     \else
         \PackageWarningNoLine{iiufrgs}{No translated keyword has been defined. Use
         the translatedkeyword command to define them.}


### PR DESCRIPTION
This pull request is a proposal/suggestion that improves three aspects of the _translated abstract_:

1. The title of the _translated abstract_ can now be defined together with the document's title, making it easier to change both when the title needs to be changed. This is achieved by adding a `\translatedtitle{...}` directive.
2. Same benefit from the previous item, but for keywords. The _normal_ keywords are defined in a different place from the translated ones, now they can be defined in the same place, making it easier for keyword changes. This creates a new directive to define the translated keywords: `\translatedkeyword{...}`
3. The `englishabstract` environment is not necessarily the abstract in English, it's actually the abstract in the _other_ language of the document. Now calling it `translatedabstract` makes it clearer and removes the necessity of any other parameters (translated title and keywords). **Warning: this only considers documents in Portuguese and English.**
4. Documents (using the `translatedabstract`) without a translated title or any translated keywords will receive a warning with instructions on how to use them.

This PR also updates the usages in the examples and keeps the original `englishabstract` environment as deprecated, making this PR a non-breaking change.

Extras:
- Updated keyword usage documentation, all keywords (first word) should start with uppercase letters. 

TODOs:
- Update `CHANGELOG`
- ~~Deprecate the `englishabstract` environment~~ (done)