### PR TITLE
Fix 'underfull \hbox' in abstract environment

### DIFF
--- a/inputs/iiufrgs.cls
+++ b/inputs/iiufrgs.cls
@@ -480,9 +480,7 @@
         \chapter*{\abstractname}\setlength{\parindent}{0pt}
 }{%
     %\par\vfill
-    %\\
     \\
-
     \vspace{\parskip}\noindent\textbf{\keywordsname:} \@abstractkw.
 }
 


### PR DESCRIPTION
Fix the 'underfull' warning:

```
Underfull \hbox (badness 10000) in paragraph at lines 3--3
```