### PR TITLE
Update for changing citation style with the new  NBR 10520/2023

### DIFF
--- a/inputs/abntex2-alf.bst
+++ b/inputs/abntex2-alf.bst
@@ -2105,7 +2105,7 @@ FUNCTION {set.default.abnt.variables}
   "$Revision: v-1.9.1 $" extract.cvs.key 'abnt.bst.revision :=
   #0 'abnt.and.type     :=     % #0 "e"; #1 "&"
   "\emph" 'abnt.emphasize :=
-  #0 'abnt.cite.style :=       %default norm version for NBR10520
+  #1 'abnt.cite.style :=       %default norm version for NBR10520
                                %#0 \cite=(AUTHOR, YEAR)
 			       %#1 \cite=(Author, YEAR)
   #0 'abnt.experimental :=


### PR DESCRIPTION
Change the default variable for citation style to be compatible with the new NBR 10520/2023